### PR TITLE
Add 'namespace' to unit-test and resolved checkov tests

### DIFF
--- a/test/module_test.go
+++ b/test/module_test.go
@@ -20,5 +20,5 @@ func TestModule(t *testing.T) {
 
 	exampleArn := terraform.Output(t, terraformOptions, "cluster_arn")
 
-	assert.Regexp(t, regexp.MustCompile(`^arn:aws:ecs:eu-west-2:[0-9]{12}:cluster/hmpps-test-unit-test`), exampleArn)
+	assert.Regexp(t, regexp.MustCompile(`^arn:aws:ecs:eu-west-2:[0-9]{12}:cluster/namespace-test-unit-test`), exampleArn)
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -12,6 +12,7 @@ module "unit_test" {
   ]
   environment = local.environment
   name        = "unit-test"
+  namespace   = "unit-test-namespace"
 
   tags = local.tags
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,5 +1,6 @@
 module "unit_test" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//cluster"
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//cluster" 
 
   ec2_capacity_instance_type     = "t3.micro"
   ec2_capacity_max_size          = "1"
@@ -18,6 +19,8 @@ module "unit_test" {
 }
 
 resource "aws_security_group" "unit_test" {
+  #checkov:skip=CKV2_AWS_5: "This will be attached to unit_test module
   name_prefix = "ecs-cluster-unit-test"
   vpc_id      = data.aws_vpc.shared.id
+  description = "unit_test security group"
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,6 +1,6 @@
 module "unit_test" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//cluster" 
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster//cluster"
 
   ec2_capacity_instance_type     = "t3.micro"
   ec2_capacity_max_size          = "1"

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -12,7 +12,7 @@ module "unit_test" {
   ]
   environment = local.environment
   name        = "unit-test"
-  namespace   = "unit-test-namespace"
+  namespace   = "namespace"
 
   tags = local.tags
 }


### PR DESCRIPTION
Updating unit-test following change to allow custom namespace [PR#51](https://github.com/ministryofjustice/modernisation-platform-terraform-ecs-cluster/pull/51)