### PR TITLE
Remove ecs_service linked iam_role

### DIFF
--- a/service/service.tf
+++ b/service/service.tf
@@ -42,8 +42,6 @@ resource "aws_ecs_service" "default" {
 
   health_check_grace_period_seconds = var.health_check_grace_period_seconds
 
-  # iam_role = var.service_role_arn
-
   wait_for_steady_state = var.wait_for_steady_state
 
   tags = var.tags
@@ -93,8 +91,6 @@ resource "aws_ecs_service" "ignore_changes" {
   }
 
   health_check_grace_period_seconds = var.health_check_grace_period_seconds
-
-  iam_role = var.service_role_arn
 
   wait_for_steady_state = var.wait_for_steady_state
 


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#iam_role

```
If using awsvpc network mode, do not specify this role. 
If your account has already created the Amazon ECS service-linked role, 
that role is used by default for your service unless you specify a role here.
```

This module only supports fargate/awsvpc network mode. 