### PR TITLE
Add default cluster configuration option for clean plan

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -5,4 +5,10 @@ resource "aws_ecs_cluster" "this" {
     name  = "containerInsights"
     value = var.enable_container_insights
   }
+
+  configuration {
+    execute_command_configuration {
+      logging = "DEFAULT"
+    }
+  }
 }


### PR DESCRIPTION
When a cluster is imported to this module, the default configuration results in the following recurring changes to a TF Plan:
```diff
      - configuration {
          - execute_command_configuration {
              - logging    = "DEFAULT" -> null
                # (1 unchanged attribute hidden)
            }
        }
```