### PR TITLE
Remove splat operator from output to get string not string

### DIFF
--- a/service/outputs.tf
+++ b/service/outputs.tf
@@ -1,5 +1,5 @@
 output "service_arn" {
-  value       = var.ignore_changes ? aws_ecs_service.ignore_changes[*].id : aws_ecs_service.default[*].id
+  value       = var.ignore_changes ? aws_ecs_service.ignore_changes[0].id : aws_ecs_service.default[0].id
   description = "The ARN for the ECS Service"
 }
 


### PR DESCRIPTION
accessing `[*]` provides a list - move to `[0]` so that a string is output instead