### PR TITLE
Don't force nonsensitive value for container definitions

### DIFF
--- a/service/task_def.tf
+++ b/service/task_def.tf
@@ -1,7 +1,7 @@
 resource "aws_ecs_task_definition" "default" {
   #checkov:skip=CKV_AWS_97:EFS transit_encryption is configurable in the module as part of the efs_volumes variable
   count                 = var.ignore_changes ? 0 : 1
-  container_definitions = nonsensitive(var.container_definitions)
+  container_definitions = var.container_definitions
   family                = var.name
 
   task_role_arn      = var.task_role_arn
@@ -43,7 +43,7 @@ resource "aws_ecs_task_definition" "default" {
 resource "aws_ecs_task_definition" "ignore_changes" {
   #checkov:skip=CKV_AWS_97:EFS transit_encryption is configurable in the module as part of the efs_volumes variable
   count                 = var.ignore_changes ? 1 : 0
-  container_definitions = nonsensitive(var.container_definitions)
+  container_definitions = var.container_definitions
   family                = var.name
 
   task_role_arn      = var.task_role_arn


### PR DESCRIPTION
Originally the `nonsensitive` function was used to stop terraform from forcing a task definition replacement on each apply. However, this only works if the value being passed into the module is in fact sensitive, otherwise it complains about the value already being nonsensitive.

Instead, the approach of allowing the consumer to determine if their value needs to be forcibly marked as nonsensitive would be a better approach to take.

In this case, the `container_definitions` attribute should be marked as so when passing it into the module.

`container_definitions = nonsensitive(module.container_definition.json_map_encoded_list)`