### PR TITLE
fix: ignore changes causes replacement of service 

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -77,9 +77,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_ecs_service.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
-| [aws_ecs_service.ignore_changes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
-| [aws_ecs_task_definition.ignore_changes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 
 ## Inputs
 

--- a/service/outputs.tf
+++ b/service/outputs.tf
@@ -1,15 +1,14 @@
 output "service_arn" {
-  value       = var.ignore_changes ? aws_ecs_service.ignore_changes[0].id : aws_ecs_service.default[0].id
+  value       = aws_ecs_service.default.id
   description = "The ARN for the ECS Service"
 }
 
 output "task_definition_arn" {
-  value       = var.ignore_changes ? aws_ecs_task_definition.ignore_changes[*].arn : aws_ecs_task_definition.default[*].arn
+  value       = aws_ecs_task_definition.defaults.arn
   description = "The ARN for the ECS Task Definition"
 }
 
 output "task_definition_string" {
-  value       = var.ignore_changes ? "${aws_ecs_task_definition.ignore_changes[0].id}:${aws_ecs_task_definition.ignore_changes[0].revision}" : "${aws_ecs_task_definition.default[0].id}:${aws_ecs_task_definition.default[0].revision}"
+  value       = "${aws_ecs_task_definition.default.id}:${aws_ecs_task_definition.default.revision}"
   description = "The JSON formatted container definition"
 }
-

--- a/service/outputs.tf
+++ b/service/outputs.tf
@@ -4,7 +4,7 @@ output "service_arn" {
 }
 
 output "task_definition_arn" {
-  value       = aws_ecs_task_definition.defaults.arn
+  value       = aws_ecs_task_definition.default.arn
   description = "The ARN for the ECS Task Definition"
 }
 

--- a/service/service.tf
+++ b/service/service.tf
@@ -45,8 +45,3 @@ resource "aws_ecs_service" "default" {
   tags = var.tags
 
 }
-
-moved {
-  from = aws_ecs_service.ignore_changes
-  to   = aws_ecs_service.default
-}

--- a/service/service.tf
+++ b/service/service.tf
@@ -1,6 +1,4 @@
 resource "aws_ecs_service" "default" {
-  count = var.ignore_changes ? 0 : 1
-
   name = var.name
 
   cluster = var.cluster_arn
@@ -48,58 +46,7 @@ resource "aws_ecs_service" "default" {
 
 }
 
-resource "aws_ecs_service" "ignore_changes" {
-  count = var.ignore_changes ? 1 : 0
-
-  name = var.name
-
-  cluster = var.cluster_arn
-
-  task_definition = var.ignore_changes ? "${aws_ecs_task_definition.ignore_changes[0].id}:${aws_ecs_task_definition.ignore_changes[0].revision}" : "${aws_ecs_task_definition.default[0].id}:${aws_ecs_task_definition.default[0].revision}"
-
-  launch_type = "FARGATE"
-  network_configuration {
-    subnets          = var.subnets
-    security_groups  = var.security_groups
-    assign_public_ip = false
-  }
-
-  desired_count                      = var.desired_count
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-
-  enable_execute_command = var.enable_execute_command
-
-  force_new_deployment = var.force_new_deployment
-
-  triggers = var.force_new_deployment ? {
-    update = plantimestamp() # force update in-place every apply
-  } : null
-  dynamic "load_balancer" {
-    for_each = var.service_load_balancers
-    content {
-      container_name   = load_balancer.value.container_name
-      container_port   = load_balancer.value.container_port
-      elb_name         = lookup(load_balancer.value, "elb_name", null)
-      target_group_arn = lookup(load_balancer.value, "target_group_arn", null)
-    }
-  }
-
-  deployment_circuit_breaker {
-    enable   = var.deployment_circuit_breaker.enable
-    rollback = var.deployment_circuit_breaker.rollback
-  }
-
-  health_check_grace_period_seconds = var.health_check_grace_period_seconds
-
-  wait_for_steady_state = var.wait_for_steady_state
-
-  tags = var.tags
-
-  lifecycle {
-    ignore_changes = [
-      task_definition,
-    ]
-  }
-
+moved {
+  from = aws_ecs_service.ignore_changes
+  to   = aws_ecs_service.default
 }

--- a/service/service.tf
+++ b/service/service.tf
@@ -20,7 +20,7 @@ resource "aws_ecs_service" "default" {
 
   force_new_deployment = var.force_new_deployment
   triggers = var.force_new_deployment ? {
-    update = plantimestamp() # force update in-place every apply
+    update = plantimestamp() # force update in-place every apply that has force_new_deployment set to true
   } : null
 
   dynamic "load_balancer" {
@@ -43,5 +43,4 @@ resource "aws_ecs_service" "default" {
   wait_for_steady_state = var.wait_for_steady_state
 
   tags = var.tags
-
 }

--- a/service/service.tf
+++ b/service/service.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_service" "default" {
 
   cluster = var.cluster_arn
 
-  task_definition = var.ignore_changes ? aws_ecs_task_definition.ignore_changes[0].arn : aws_ecs_task_definition.default[0].arn
+  task_definition = aws_ecs_task_definition.default.arn
 
   launch_type = "FARGATE"
   network_configuration {

--- a/service/task_def.tf
+++ b/service/task_def.tf
@@ -1,6 +1,5 @@
 resource "aws_ecs_task_definition" "default" {
   #checkov:skip=CKV_AWS_97:EFS transit_encryption is configurable in the module as part of the efs_volumes variable
-  count                 = var.ignore_changes ? 0 : 1
   container_definitions = var.container_definitions
   family                = var.name
 
@@ -8,6 +7,8 @@ resource "aws_ecs_task_definition" "default" {
   execution_role_arn = var.task_exec_role_arn
 
   network_mode = "awsvpc"
+
+  track_latest = true
 
   cpu    = var.task_cpu
   memory = var.task_memory
@@ -40,53 +41,7 @@ resource "aws_ecs_task_definition" "default" {
   tags = var.tags
 }
 
-resource "aws_ecs_task_definition" "ignore_changes" {
-  #checkov:skip=CKV_AWS_97:EFS transit_encryption is configurable in the module as part of the efs_volumes variable
-  count                 = var.ignore_changes ? 1 : 0
-  container_definitions = var.container_definitions
-  family                = var.name
-
-  task_role_arn      = var.task_role_arn
-  execution_role_arn = var.task_exec_role_arn
-
-  network_mode = "awsvpc"
-
-  cpu    = var.task_cpu
-  memory = var.task_memory
-
-  ephemeral_storage {
-    size_in_gib = var.ephemeral_storage_size_in_gib
-  }
-
-  dynamic "volume" {
-    for_each = var.efs_volumes
-    content {
-      host_path = lookup(volume.value, "host_path", null)
-      name      = volume.value.name
-
-      dynamic "efs_volume_configuration" {
-        for_each = lookup(volume.value, "efs_volume_configuration", [])
-
-        content {
-          file_system_id          = lookup(efs_volume_configuration.value, "file_system_id", null)
-          root_directory          = lookup(efs_volume_configuration.value, "root_directory", null)
-          transit_encryption      = lookup(efs_volume_configuration.value, "transit_encryption", null)
-          transit_encryption_port = lookup(efs_volume_configuration.value, "transit_encryption_port", null)
-
-          dynamic "authorization_config" {
-            for_each = lookup(efs_volume_configuration.value, "authorization_config", [])
-            content {
-              access_point_id = lookup(authorization_config.value, "access_point_id", null)
-              iam             = lookup(authorization_config.value, "iam", null)
-            }
-          }
-        }
-      }
-    }
-  }
-  tags = var.tags
-
-  lifecycle {
-    ignore_changes = [container_definitions]
-  }
+moved {
+  from = aws_ecs_task_definition.ignore_changes
+  to   = aws_ecs_task_definition.default
 }

--- a/service/task_def.tf
+++ b/service/task_def.tf
@@ -40,8 +40,3 @@ resource "aws_ecs_task_definition" "default" {
   }
   tags = var.tags
 }
-
-moved {
-  from = aws_ecs_task_definition.ignore_changes
-  to   = aws_ecs_task_definition.default
-}


### PR DESCRIPTION
This pull request includes changes involving the removal of the `ignore_changes` resources and associated logic, simplifying the configuration and outputs. The reason this behaviour was introduced was so that task definition changes could be optionally ignored however this has resulted in undesired behaviour where the service is recreated if the task definition needs to be ignore/unignored. Consequently downtimeless deployments were achievable. These change restore the provider intended configuration even if it does mean that some task definitions will be needlessly recreated.

This change will cause the service to be recreated if the last successful apply had `ignore_changes = true`

Summary:

* [`service/README.md`](diffhunk://#diff-68428fcece754bcc1936151add57dbc36b8d79f2ab4893ff1ab3206cffe92bc4L80-L82): Removed references to `aws_ecs_service.ignore_changes` and `aws_ecs_task_definition.ignore_changes` resources.
* [`service/outputs.tf`](diffhunk://#diff-99caeec24a6819d2b02201dd2acd8f723047e270f98189ccdaf84f2f8af639c4L2-L15): Updated output values to reference only the `default` ECS service and task definition resources.
* [`service/service.tf`](diffhunk://#diff-e1f92fa4b361a0601748d640508ef8dd89f2da6208167fddc7e55c7a40bf44d5L2-R6): Removed the `ignore_changes` ECS service resource and associated conditional logic. [[1]](diffhunk://#diff-e1f92fa4b361a0601748d640508ef8dd89f2da6208167fddc7e55c7a40bf44d5L2-R6) [[2]](diffhunk://#diff-e1f92fa4b361a0601748d640508ef8dd89f2da6208167fddc7e55c7a40bf44d5L48-L104)
* [`service/task_def.tf`](diffhunk://#diff-bebd2202056e06d85834f3efc76fb60f1cb3b57e56ce0eabdcf334268b07ad47L3): Removed the `ignore_changes` ECS task definition resource and associated conditional logic. [[1]](diffhunk://#diff-bebd2202056e06d85834f3efc76fb60f1cb3b57e56ce0eabdcf334268b07ad47L3) [[2]](diffhunk://#diff-bebd2202056e06d85834f3efc76fb60f1cb3b57e56ce0eabdcf334268b07ad47L88-L91)