### PR TITLE
feat: add option to pin service to task def revision

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -94,8 +94,8 @@ No modules.
 | <a name="input_ephemeral_storage_size_in_gib"></a> [ephemeral\_storage\_size\_in\_gib](#input\_ephemeral\_storage\_size\_in\_gib) | The size of the ephemeral storage to use for the task definition | `number` | `30` | no |
 | <a name="input_force_new_deployment"></a> [force\_new\_deployment](#input\_force\_new\_deployment) | Whether to force a new deployment of the service | `bool` | `false` | no |
 | <a name="input_health_check_grace_period_seconds"></a> [health\_check\_grace\_period\_seconds](#input\_health\_check\_grace\_period\_seconds) | The grace period to allow for healthy instances to warm up before checking them | `number` | `0` | no |
-| <a name="input_ignore_changes"></a> [ignore\_changes](#input\_ignore\_changes) | Whether to ignore changes to the service, task definition, container definition | `bool` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name of the ECS service | `string` | n/a | yes |
+| <a name="input_pin_task_definition_revision"></a> [pin\_task\_definition\_revision](#input\_pin\_task\_definition\_revision) | The revision of the task definition to use | `number` | `0` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to associate with the service | `list(string)` | n/a | yes |
 | <a name="input_service_load_balancers"></a> [service\_load\_balancers](#input\_service\_load\_balancers) | A list of load balancers to associate with the service | <pre>list(object({<br/>    container_name   = string<br/>    container_port   = number<br/>    elb_name         = optional(string)<br/>    target_group_arn = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_service_role_arn"></a> [service\_role\_arn](#input\_service\_role\_arn) | The ARN of the IAM role to use for the service | `string` | n/a | yes |

--- a/service/service.tf
+++ b/service/service.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_service" "default" {
 
   cluster = var.cluster_arn
 
-  task_definition = aws_ecs_task_definition.default.arn
+  task_definition = var.pin_task_definition_revision != 0 ? "${aws_ecs_task_definition.default.arn}:${aws_ecs_task_definition.default.revision}" : aws_ecs_task_definition.default.arn
 
   launch_type = "FARGATE"
   network_configuration {
@@ -20,8 +20,8 @@ resource "aws_ecs_service" "default" {
 
   force_new_deployment = var.force_new_deployment
   triggers = var.force_new_deployment ? {
-    update = plantimestamp() # force update in-place every apply that has force_new_deployment set to true
-  } : null
+    redeployment = plantimestamp() # force update in-place every apply that has force_new_deployment set to true
+  } : {}
 
   dynamic "load_balancer" {
     for_each = var.service_load_balancers

--- a/service/service.tf
+++ b/service/service.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_service" "default" {
 
   cluster = var.cluster_arn
 
-  task_definition = var.pin_task_definition_revision != 0 ? "${aws_ecs_task_definition.default.arn}:${var.pin_task_definition_revision}" : aws_ecs_task_definition.default.arn
+  task_definition = var.pin_task_definition_revision != 0 ? "${aws_ecs_task_definition.default.arn_without_revision}:${var.pin_task_definition_revision}" : aws_ecs_task_definition.default.arn
 
   launch_type = "FARGATE"
   network_configuration {

--- a/service/service.tf
+++ b/service/service.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_service" "default" {
 
   cluster = var.cluster_arn
 
-  task_definition = var.pin_task_definition_revision != 0 ? "${aws_ecs_task_definition.default.arn}:${aws_ecs_task_definition.default.revision}" : aws_ecs_task_definition.default.arn
+  task_definition = var.pin_task_definition_revision != 0 ? "${aws_ecs_task_definition.default.arn}:${var.pin_task_definition_revision}" : aws_ecs_task_definition.default.arn
 
   launch_type = "FARGATE"
   network_configuration {

--- a/service/variables.tf
+++ b/service/variables.tf
@@ -20,11 +20,6 @@ variable "container_definitions" {
   sensitive   = false
 }
 
-variable "ignore_changes" {
-  type        = bool
-  description = "Whether to ignore changes to the service, task definition, container definition"
-}
-
 variable "efs_volumes" {
   type = list(object({
     host_path = string
@@ -150,4 +145,10 @@ variable "deployment_circuit_breaker" {
     enable   = false
     rollback = false
   }
+}
+
+variable "pin_task_definition_revision" {
+  type        = number
+  description = "The revision of the task definition to use"
+  default     = 0
 }


### PR DESCRIPTION
This pull request includes updates to the ECS service configuration to add a new variable for pinning task definition revisions, and to removes the now unused `ignore_changes` variable.

If you pin the revision, the ECS service won't be redeployed by terraform unless you manually update it. Task definitions will continue to be recreated, they just won't take effect.

### ECS Service Configuration Updates:

* [`service/README.md`](diffhunk://#diff-68428fcece754bcc1936151add57dbc36b8d79f2ab4893ff1ab3206cffe92bc4L97-R98): Added a new input variable `pin_task_definition_revision` to specify the revision of the task definition to use. Removed the `ignore_changes` input variable.
* [`service/service.tf`](diffhunk://#diff-e1f92fa4b361a0601748d640508ef8dd89f2da6208167fddc7e55c7a40bf44d5L6-R6): Updated the `task_definition` attribute to use the `pin_task_definition_revision` variable if it is set. Adjusted the `triggers` attribute to use an empty map instead of `null` when `force_new_deployment` is true. [[1]](diffhunk://#diff-e1f92fa4b361a0601748d640508ef8dd89f2da6208167fddc7e55c7a40bf44d5L6-R6) [[2]](diffhunk://#diff-e1f92fa4b361a0601748d640508ef8dd89f2da6208167fddc7e55c7a40bf44d5L23-R24)
* [`service/variables.tf`](diffhunk://#diff-ba71458221fd08c9e4d6eb94d9d753bbcd12a3d50ef68b185406bccaf46e3f0aL23-L27): Added a new variable `pin_task_definition_revision` to specify the revision of the task definition. Removed the `ignore_changes` variable. [[1]](diffhunk://#diff-ba71458221fd08c9e4d6eb94d9d753bbcd12a3d50ef68b185406bccaf46e3f0aL23-L27) [[2]](diffhunk://#diff-ba71458221fd08c9e4d6eb94d9d753bbcd12a3d50ef68b185406bccaf46e3f0aR149-R154)