### PR TITLE
Updated dependabot script to use directories key

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 dependabot_file=.github/dependabot.yml
 
+# Clear the dependabot file
+> $dependabot_file
+
 # Get a list of Terraform folders
 all_tf_folders=`find . -type f -name '*.tf' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
 all_env_test_folders=`find . -type f -name 'go.mod' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
@@ -18,7 +21,7 @@ echo "Writing dependabot.yml file"
 # Creates a dependabot file to avoid having to manually add each new TF folder or go.mod file
 # Add any additional fixed entries in this top section
   cat > $dependabot_file << EOL
-# This file is auto-generated here, do not manually amend. 
+# This file is auto-generated here, do not manually amend.
 # https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-dependabot.sh
 
 version: 2
@@ -33,20 +36,20 @@ updates:
   # See: github.com/dependabot/dependabot-core/issues/2178
 EOL
 
-for folder in $all_tf_folders
-do
-echo "Generating entry for ${folder}"
+echo "Generating entry for Terraform ecosystem"
 echo "  - package-ecosystem: \"terraform\"" >> $dependabot_file
-echo "    directory: \"/${folder}\"" >> $dependabot_file
+echo "    directories:" >> $dependabot_file
+for folder in $all_tf_folders; do
+  echo "      - \"/$folder\"" >> $dependabot_file
+done
 echo "    schedule:" >> $dependabot_file
 echo "      interval: \"daily\"" >> $dependabot_file
-done
 
-for folder in $all_env_test_folders
-do
-echo "Generating entry for ${folder}"
+echo "Generating entry for Gomod ecosystem"
 echo "  - package-ecosystem: \"gomod\"" >> $dependabot_file
-echo "    directory: \"/${folder}\"" >> $dependabot_file
+echo "    directories:" >> $dependabot_file
+for folder in $all_env_test_folders; do
+  echo "      - \"/$folder\"" >> $dependabot_file
+done
 echo "    schedule:" >> $dependabot_file
 echo "      interval: \"daily\"" >> $dependabot_file
-done


### PR DESCRIPTION
This PR is tracked upstream by [#7053](https://github.com/ministryofjustice/modernisation-platform/pull/7503).

This PR changes the dependabot action creation script to the following:
* Clear the contents of the action at the start of the script
* Use the `directories:` key in favour of multiple `directory:` keys